### PR TITLE
Version106

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.6 - 9/5/2023
+
+- Fixed [cms:siblings Nav tag](https://github.com/avonderluft/occams/wiki/Content-Tags#siblings) to handle edge case when page(s) are excluded by the `exclude` parameter
+- Added [cms:children Nav tag](https://github.com/avonderluft/occams/wiki/Content-Tags#children) to render unordered list of links for children of current page
+
 ## v1.0.5 - 8/31/2023
 
 - All tests now green on Rails 6.1 and 7.0, each tested with rubies 2.7.8, 3.1.4 and 3.2.2.

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ group :development, :test do
   gem 'capybara',           '~> 3.39.0'
   gem 'image_processing',   '>= 1.2'
   gem 'kaminari',           '~> 1.2', '>= 1.2.2'
-  gem 'puma',               '~> 3.12.2'
   gem 'rubocop',            '~> 0.55.0', require: false
   gem 'selenium-webdriver', '~> 4.9.0'
   gem 'sqlite3',            '~> 1.4.2'

--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 # ocCaM'S
 
-Prefer Simplicity
-
-## Raison d'etre
-
-ocCaM'S is a revival of [ComfortableMexicanSofa](https://github.com/comfy/comfortable-mexican-sofa), with all due thanks and acknowledgements to [Oleg Khabarov](https://github.com/GBH), et al. 'Comfy' was the simplest and cleanest Rails-based CMS that I had used. Its last commit was in 2020, and I simply did not want to see it die on the vine as [RadiantCMS](https://github.com/radiant/radiant) did some years ago.
+[![Gem Version](https://img.shields.io/gem/v/occams.svg?style=flat)](http://rubygems.org/gems/occams)
+[![Gem Downloads](https://img.shields.io/gem/dt/occams.svg?style=flat)](http://rubygems.org/gems/occams)
 
 ```
              ____      __  __ _ ____
@@ -14,6 +11,13 @@ ocCaM'S is a revival of [ComfortableMexicanSofa](https://github.com/comfy/comfor
  \___/ \___|\____\__,_|_|  |_| |____/
 
 ``` 
+
+Prefer Simplicity.
+
+## Raison d'etre
+
+ocCaM'S is a revival of [ComfortableMexicanSofa](https://github.com/comfy/comfortable-mexican-sofa), with all due thanks and acknowledgements to [Oleg Khabarov](https://github.com/GBH), et al. 'Comfy' was the simplest and cleanest Rails-based CMS that I had used. Its last commit was in 2020, and I simply did not want to see it die on the vine as [RadiantCMS](https://github.com/radiant/radiant) did some years ago.
+
 
 ## The name
 
@@ -36,7 +40,7 @@ Referring to the [ComfortableMexicanSofa](https://github.com/comfy/comfortable-m
 ## Dependencies
 
 * File attachments are handled by [ActiveStorage](https://github.com/rails/rails/tree/master/activestorage). Make sure that you can run appropriate migrations by running: `rails active_storage:install` and then `rake db:migrate`
-* Image resizing is done on Rails 7 or greater, with[ImageMagick](http://www.imagemagick.org/script/download.php), so make sure it's installed
+* Image resizing is done with[ImageMagick](http://www.imagemagick.org/script/download.php), so make sure it's installed
 * Pagination is handled by [kaminari](https://github.com/amatsuda/kaminari) or [will_paginate](https://github.com/mislav/will_paginate). Please add one of those to your Gemfile.
 
 ## Compatibility

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,6 +1,7 @@
 # ToDos
 
-- set up CI 
+- set up Buildkite CI and add build badge to README
+- add duplicate page function in admin UI
 - add admin content search to list layouts, pages and snippets - see https://blog.robertsj.com/search/
 - add application console for testing
 - add feature to resize file_link'd images

--- a/lib/occams/content.rb
+++ b/lib/occams/content.rb
@@ -32,4 +32,5 @@ require_relative 'content/tags/template'
 
 require_relative 'content/tags/audio'
 require_relative 'content/tags/breadcrumbs'
+require_relative 'content/tags/children'
 require_relative 'content/tags/siblings'

--- a/lib/occams/content/tags/children.rb
+++ b/lib/occams/content/tags/children.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Nav Tag for unordered list of links to the children of the current page
+#   {{ cms:children }}
+#   {{ cms:children style: "font-weight: bold", exclude: "404-page, search-page" }}
+# To customize your children style, add a 'children' id to your CSS, e.g
+# #children {
+#   color: #006633;
+#   font-size: 90%;
+#   margin-bottom: 4px;
+#   font-style: italic;
+# }
+# and/or pass in style overrides with the 'style' parameter, as above
+#
+# To exclude children, list their slugs with the 'exclude' parameter
+# as comma-delimited string, e.g. as above - exclude: "404-page, search-page"
+
+class Occams::Content::Tag::Children < Occams::Content::Tag
+  attr_reader :list, :style, :locals
+
+  def initialize(context:, params: [], source: nil)
+    super
+    @locals = params.extract_options!
+    @style  = ''
+    @style  = "<style>#children {#{@locals['style']}}</style>" if @locals['style']
+    @exclude = []
+    @exclude = @locals['exclude'].split(',') if @locals['exclude']
+    @list = ''
+    # ActiveRecord_Associations_CollectionProxy
+    page_children = context.children.order(:position).to_ary
+    page_children.delete_if { |child| @exclude.include? child.slug }
+    return unless page_children.any?
+
+    @list = '<ul id="children">'
+    page_children.each do |c|
+      next if Rails.env == 'production' && !c.is_published
+
+      @list += "<li><a href=#{c.url(relative: true)}>#{c.label}</a></li>"
+    end
+    @list += '</ul>'
+  end
+
+  def content
+    format("#{@style}#{@list}")
+  end
+end
+
+Occams::Content::Renderer.register_tag(
+  :children, Occams::Content::Tag::Children
+)

--- a/lib/occams/content/tags/siblings.rb
+++ b/lib/occams/content/tags/siblings.rb
@@ -6,10 +6,8 @@
 # To customize your siblings style, add a 'siblings' id to your CSS, e.g
 # #siblings {
 #   color: #006633;
-#   font-family: Verdana, Arial, Helvetica, sans-serif;
 #   font-size: 95%;
 #   margin-top: 12px;
-#   margin-bottom: 4px;
 #   font-style: italic;
 # }
 # and/or pass in style overrides with the 'style' parameter (see above)
@@ -33,11 +31,11 @@ class Occams::Content::Tag::Siblings < Occams::Content::Tag
 
     prevp = false
     sibs = context.self_and_siblings.sort_by(&:position)
+    sibs.delete_if { |sib| @exclude.include? sib.slug }
     page_idx = sibs.index(context)
     sibs.each do |sib|
       sib_idx = sibs.index(sib)
       next if sibs.index(sib) == page_idx
-      next if @exclude.include? sib.slug
       next if Rails.env == 'production' && !sib.is_published
 
       if sib_idx == page_idx - 1

--- a/lib/occams/version.rb
+++ b/lib/occams/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Occams
-  VERSION = '1.0.5'
+  VERSION = '1.0.6'
 end

--- a/test/gemfiles/6.1.gemfile
+++ b/test/gemfiles/6.1.gemfile
@@ -10,7 +10,6 @@ group :development, :test do
   gem 'byebug',             '~> 10.0.0', platforms: %i[mri mingw x64_mingw]
   gem 'capybara',           '~> 2.17.0'
   gem 'kaminari',           '~> 1.1.1'
-  gem 'puma',               '~> 3.12.2'
   gem 'rubocop',            '~> 0.55.0', require: false
   gem 'selenium-webdriver', '~> 3.9.0'
   gem 'sqlite3',            '~> 1.4.2'

--- a/test/gemfiles/7.0.gemfile
+++ b/test/gemfiles/7.0.gemfile
@@ -11,7 +11,6 @@ group :development, :test do
   gem 'byebug',             '~> 10.0.0', platforms: %i[mri mingw x64_mingw]
   gem 'capybara',           '~> 3.39.0'
   gem 'kaminari',           '~> 1.2', '>= 1.2.2'
-  gem 'puma',               '~> 3.12.2'
   gem 'rubocop',            '~> 0.55.0', require: false
   gem 'selenium-webdriver', '~> 4.9.0'
   gem 'sqlite3',            '~> 1.4.2'

--- a/test/lib/content/renderer_test.rb
+++ b/test/lib/content/renderer_test.rb
@@ -39,6 +39,7 @@ class ContentRendererTest < ActiveSupport::TestCase
     'template' => Occams::Content::Tag::Template,
     'audio' => Occams::Content::Tag::Audio,
     'breadcrumbs' => Occams::Content::Tag::Breadcrumbs,
+    'children' => Occams::Content::Tag::Children,
     'siblings' => Occams::Content::Tag::Siblings
   }.freeze
 

--- a/test/lib/content/tags/children_test.rb
+++ b/test/lib/content/tags/children_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require_relative '../../../test_helper'
+
+class ContentTagsChildrenTest < ActiveSupport::TestCase
+  setup do
+    @site   = occams_cms_sites(:default)
+    @layout = occams_cms_layouts(:default)
+    @page   = occams_cms_pages(:default)
+    @parent = @site.pages.create!(layout: @layout, parent: @page, label: 'Parent', slug: 'parent')
+    @child1 = @site.pages.create!(layout: @layout, parent: @parent, label: 'Child1', slug: 'child1')
+    @child2 = @site.pages.create!(layout: @layout, parent: @parent, label: 'Child2', slug: 'child2')
+    @child3 = @site.pages.create!(layout: @layout, parent: @parent, label: 'Child3', slug: 'child3')
+    @child4 = @site.pages.create!(layout: @layout, parent: @parent, label: 'Child4', slug: 'child4')
+  end
+
+  def test_init
+    tag = Occams::Content::Tag::Children.new(
+      context: @parent,
+      params: []
+    )
+    assert_equal ({}), tag.locals
+  end
+
+  def test_init_with_style
+    tag = Occams::Content::Tag::Children.new(
+      context: @parent,
+      params: [{ 'style' => 'font-weight: bold' }]
+    )
+    assert_equal '<style>#children {font-weight: bold}</style>', tag.style
+  end
+
+  def test_render
+    tag = Occams::Content::Tag::Children.new(
+      context: @parent,
+      params: [{ 'style' => 'font-weight: bold' }]
+    )
+    html = "<style>#children {font-weight: bold}</style><ul id=\"children\">\
+<li><a href=/parent/child1>Child1</a></li><li><a href=/parent/child2>Child2</a></li>\
+<li><a href=/parent/child3>Child3</a></li><li><a href=/parent/child4>Child4</a></li></ul>"
+    assert_equal html, tag.render
+  end
+
+  def test_render_with_exclusions
+    tag = Occams::Content::Tag::Children.new(
+      context: @parent,
+      params: [{ 'exclude' => 'child2,child3' }]
+    )
+    html = "<ul id=\"children\"><li><a href=/parent/child1>Child1</a></li>\
+<li><a href=/parent/child4>Child4</a></li></ul>"
+    assert_equal html, tag.render
+  end
+
+  def test_render_with_no_kids
+    tag = Occams::Content::Tag::Children.new(
+      context: @child4,
+      params: []
+    )
+    assert_equal '', tag.render
+  end
+end

--- a/test/lib/content/tags/siblings_test.rb
+++ b/test/lib/content/tags/siblings_test.rb
@@ -11,6 +11,7 @@ class ContentTagsSiblingsTest < ActiveSupport::TestCase
     @second = @site.pages.create!(layout: @layout, parent: @page, label: 'Second', slug: 'second')
     @third = @site.pages.create!(layout: @layout, parent: @page, label: 'Third', slug: 'third')
     @fourth = @site.pages.create!(layout: @layout, parent: @page, label: 'Fourth', slug: 'fourth')
+    @fifth = @site.pages.create!(layout: @layout, parent: @page, label: 'Fifth', slug: 'fifth')
   end
 
   def test_init
@@ -37,6 +38,16 @@ class ContentTagsSiblingsTest < ActiveSupport::TestCase
     html = "<style>#siblings {font-weight: bold}</style><div id=\"siblings\">\
 <a href=/second>Second</a> &laquo;&nbsp;<em>Previous</em> \
 &bull; <em>Next</em>&nbsp;&raquo; <a href=/fourth>Fourth</a></div>"
+    assert_equal html, tag.render
+  end
+
+  def test_render_with_exclusions
+    tag = Occams::Content::Tag::Siblings.new(
+      context: @third,
+      params: [{ 'exclude' => 'second,fourth' }]
+    )
+    html = "<div id=\"siblings\"><a href=/first>First</a> &laquo;&nbsp;<em>Previous</em> \
+&bull; <em>Next</em>&nbsp;&raquo; <a href=/fifth>Fifth</a></div>"
     assert_equal html, tag.render
   end
 end


### PR DESCRIPTION
### Summary

- Fixed [cms:siblings Nav tag](https://github.com/avonderluft/occams/wiki/Content-Tags#siblings) to handle edge case when page(s) are excluded by the `exclude` parameter
- Added [cms:children Nav tag](https://github.com/avonderluft/occams/wiki/Content-Tags#children) to render unordered list of links for children of current page