### PR TITLE
README: Add to use ComfortableMediaSurfer instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![Gem Downloads](https://img.shields.io/gem/dt/occams.svg?style=flat)](http://rubygems.org/gems/occams)
 [![GitHub Release Date - Published_At](https://img.shields.io/github/release-date/avonderluft/occams?label=last%20release&color=seagreen)](https://github.com/avonderluft/occams/releases)
 
+**We recommend using [ComfortableMediaSurfer](https://github.com/shakacode/comfortable-media-surfer) instead.**
+
 ***Prefer Simplicity.***
 
 <a href="https://en.wikipedia.org/wiki/William_of_Ockham" target="_blank">

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Gem Downloads](https://img.shields.io/gem/dt/occams.svg?style=flat)](http://rubygems.org/gems/occams)
 [![GitHub Release Date - Published_At](https://img.shields.io/github/release-date/avonderluft/occams?label=last%20release&color=seagreen)](https://github.com/avonderluft/occams/releases)
 
-**We recommend using [ComfortableMediaSurfer](https://github.com/shakacode/comfortable-media-surfer) instead.**
+***We recommend using [ComfortableMediaSurfer](https://github.com/shakacode/comfortable-media-surfer) instead.***
 
 ***Prefer Simplicity.***
 


### PR DESCRIPTION
### Summary

https://github.com/avonderluft/occams/issues/20#issuecomment-2543326724
>But also be aware, that we're in the process of moving active development to https://github.com/shakacode/comfortable-media-surfer sponsored by ShakaCode and @ justin808


The above is difficult to understand from outsiders using ocCaM'S.
Therefore, I add a recommendation to use [ComfortableMediaSurfer](https://github.com/shakacode/comfortable-media-surfer) instead of this gem to `README.md`.